### PR TITLE
Parameterize ELB protocol

### DIFF
--- a/api/models/templates/app.tmpl
+++ b/api/models/templates/app.tmpl
@@ -342,7 +342,7 @@
                 {
                   "Protocol": "SSL",
                   "LoadBalancerPort": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Balancer" },
-                  "InstanceProtocol": "{ "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}InsecureProtocol" }",
+                  "InstanceProtocol": "TCP",
                   "InstancePort": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Host" },
                   "SSLCertificateId": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Certificate" }
                 }

--- a/api/models/templates/app.tmpl
+++ b/api/models/templates/app.tmpl
@@ -251,6 +251,12 @@
         "Description" : "",
         "AllowedValues": [ "Yes", "No" ]
       },
+      "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}InsecureProtocol": {
+        "Type" : "String",
+        "Default" : "HTTP",
+        "Description" : "",
+        "AllowedValues": [ "HTTP", "TCP" ]
+      },
     {{ end }}
   {{ end }}
 {{ end }}
@@ -320,9 +326,9 @@
           {{ range .PortMappings }}
             { "Fn::If": [ "Blank{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Certificate",
               {
-                "Protocol": "TCP",
+                "Protocol": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}InsecureProtocol" },
                 "LoadBalancerPort": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Balancer" },
-                "InstanceProtocol": "TCP",
+                "InstanceProtocol": "{ "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}InsecureProtocol" }",
                 "InstancePort": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Host" }
               },
               { "Fn::If": [ "Secure{{ upper $balancer.ProcessName }}Port{{ .Balancer }}",
@@ -336,7 +342,7 @@
                 {
                   "Protocol": "SSL",
                   "LoadBalancerPort": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Balancer" },
-                  "InstanceProtocol": "TCP",
+                  "InstanceProtocol": "{ "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}InsecureProtocol" }",
                   "InstancePort": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Host" },
                   "SSLCertificateId": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Certificate" }
                 }

--- a/api/models/templates/app.tmpl
+++ b/api/models/templates/app.tmpl
@@ -251,9 +251,9 @@
         "Description" : "",
         "AllowedValues": [ "Yes", "No" ]
       },
-      "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}InsecureProtocol": {
+      "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Protocol": {
         "Type" : "String",
-        "Default" : "HTTP",
+        "Default" : "TCP",
         "Description" : "",
         "AllowedValues": [ "HTTP", "TCP" ]
       },
@@ -326,9 +326,9 @@
           {{ range .PortMappings }}
             { "Fn::If": [ "Blank{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Certificate",
               {
-                "Protocol": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}InsecureProtocol" },
+                "Protocol": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Protocol" },
                 "LoadBalancerPort": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Balancer" },
-                "InstanceProtocol": "{ "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}InsecureProtocol" }",
+                "InstanceProtocol": "{ "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Protocol" }",
                 "InstancePort": { "Ref": "{{ upper $balancer.ProcessName }}Port{{ .Balancer }}Host" }
               },
               { "Fn::If": [ "Secure{{ upper $balancer.ProcessName }}Port{{ .Balancer }}",


### PR DESCRIPTION
This adds a new parameter to the stack called `{{ upper $balancer.ProcessName }}Port{{ .Balancer }}InsecureProtocol` (e.g. `MainPort80InsecureProtocol`), which controls the protocol the ELB uses for non-SSL connections. 

The options are `TCP` and `HTTP`. This matters as the ELB will only set an `X-Forwarded-For` header on `HTTP` ELBs.
## Release Playbook
- [ ] Rebase against master
- [ ] Pass checks
- [ ] Release branch ()
- [ ] Pass CI ()
- [ ] Code review
- [ ] Merge into master
- [ ] Release master ()
- [ ] Pass CI ()
- [ ] Update dev and testing racks
- [ ] Publish release
- [ ] Release CLI
